### PR TITLE
Missing comma in markdown

### DIFF
--- a/docs/keymetrics/pmx.md
+++ b/docs/keymetrics/pmx.md
@@ -33,7 +33,7 @@ var pmx = require('pmx').init({
   errors        : true, // Exceptions loggin (default: true)
   custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
   network       : true, // Network monitoring at the application level
-  ports         : true  // Shows which ports your app is listening on (default: false)
+  ports         : true, // Shows which ports your app is listening on (default: false)
   alert_enabled : true  // Enable alert sub field in custom metrics   (default: false)
 });
 ```


### PR DESCRIPTION
A missing comma causes error when copy-paste the script
